### PR TITLE
feat: add an option to log only error

### DIFF
--- a/inc/Logger/Process.php
+++ b/inc/Logger/Process.php
@@ -14,7 +14,7 @@ class Process {
 
 		$this->wsOptions = get_option( 'wp_smtp_options' );
 
-		if ( ! isset( $this->wsOptions['disable_logs'] ) || 'yes' !== $this->wsOptions['disable_logs'] ) {
+		if ( ! isset( $this->wsOptions['disable_logs'] ) || 'no' === $this->wsOptions['disable_logs'] ) {
 			add_filter( 'wp_mail', array( $this, 'log_mails' ), PHP_INT_MAX );
 		}
 

--- a/wp_smtp_admin.php
+++ b/wp_smtp_admin.php
@@ -210,19 +210,26 @@ if ( isset( $_POST['wp_smtp_test'] ) && isset( $_POST['wp_smtp_nonce_test'] ) ) 
 			</tr>
 			<tr valign="top">
 				<th scope="row">
-					<?php esc_html_e( 'Disable Logs', 'wp-smtp' ); ?>
+					<?php esc_html_e( 'Log level', 'wp-smtp' ); ?>
 				</th>
 				<td>
-					<label>
-						<input type="checkbox" name="wp_smtp_disable_logs"
-							   value="yes" 
-							   <?php
-								if ( isset( $this->wsOptions['disable_logs'] ) && 'yes' === $this->wsOptions['disable_logs'] ) {
-									echo 'checked="checked"';}
+					<select name="wp_smtp_disable_logs">
+					  <option value="no" <?php
+								if ( isset( $this->wsOptions['disable_logs'] ) && 'no' === $this->wsOptions['disable_logs'] ) {
+									echo 'selected';}
 								?>
-								 />
-						<?php esc_html_e( 'Disable the email logging functionality.', 'wp-smtp' ); ?>
-					</label>
+								><?php esc_html_e( 'All emails', 'wp-smtp' ); ?></option>
+					  <option value="error"" <?php
+								if ( isset( $this->wsOptions['disable_logs'] ) && 'error' === $this->wsOptions['disable_logs'] ) {
+									echo 'selected';}
+								?>
+								><?php esc_html_e( 'Only error', 'wp-smtp' ); ?></option>
+					  <option value="yes"" <?php
+								if ( isset( $this->wsOptions['disable_logs'] ) && 'yes' === $this->wsOptions['disable_logs'] ) {
+									echo 'selected';}
+								?>
+								><?php esc_html_e( 'No log', 'wp-smtp' ); ?></option>
+					</select>
 				</td>
 			</tr>
 		</table>


### PR DESCRIPTION
Address this issue : https://github.com/WPChill/wp-smtp/issues/18

Add a new level of value for disable_logs with value="error"